### PR TITLE
Updated libraries.yml

### DIFF
--- a/reboot.libraries.yml
+++ b/reboot.libraries.yml
@@ -1,7 +1,5 @@
 bootstrap:
   css:
-    base:
-      css/bootstrap.min.css: {}
     theme:
       css/bootstrap-theme.min.css: {}
 


### PR DESCRIPTION
There is no longer a bootstrap-theme.min.css. Removed that from the libraries file. Our tutorial exercise is up to date, as is the Pages file, but the PDF is out-of-date.
@eojthebrave PDF and Keynote should be checked for this change.